### PR TITLE
ES-975464 - Resolve the ReadMe file length issue in this sample repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@ This example illustrates how to define summary rows using [AttachedProperty](htt
 
 [WPF DataGrid](https://www.syncfusion.com/wpf-ui-controls/datagrid) (SfDataGrid) provides support to show the column summary. If the DataContext of `SfDataGrid` is ViewModel, you can bind [SummaryColumns](http://help.syncfusion.com/cr/cref_files/wpf/Syncfusion.SfGrid.WPF~Syncfusion.UI.Xaml.Grid.GridSummaryRow~SummaryColumns.html) to a property in ViewModel using the [AttachedProperty](https://docs.microsoft.com/en-us/dotnet/framework/wpf/advanced/attached-properties-overview) of type `List<GridSummaryColumn>`.
 
-Refer to the code example in the following KB article to define an `AttachedProperty` of type List<GridSummaryColumn>.
+Refer to the code example in the following KB article to define an `AttachedProperty` of type `List<GridSummaryColumn>`.
 
 KB article - [How to define summary rows using AttachedProperty in WPF and UWP DataGrid (SfDataGrid)](https://www.syncfusion.com/kb/9838/how-to-define-summary-rows-using-attached-property-in-wpf-datagrid-sfdatagrid)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # How to define summary rows using AttachedProperty in WPF and UWP DataGrid (SfDataGrid)?
 
-This example illustrates how to define summary rows using AttachedProperty in [WPF DataGrid](https://www.syncfusion.com/wpf-ui-controls/datagrid) (SfDataGrid).
+This example illustrates how to define summary rows using [AttachedProperty](https://learn.microsoft.com/en-us/dotnet/desktop/wpf/properties/attached-properties-overview) in [WPF DataGrid](https://www.syncfusion.com/wpf-ui-controls/datagrid) (SfDataGrid).
 
-[WPF DataGrid](https://www.syncfusion.com/wpf-ui-controls/datagrid) (SfDataGrid) provides support to show the column summary. If the DataContext of SfDataGrid is ViewModel, you can bind [SummaryColumns](http://help.syncfusion.com/cr/cref_files/wpf/Syncfusion.SfGrid.WPF~Syncfusion.UI.Xaml.Grid.GridSummaryRow~SummaryColumns.html) to a property in ViewModel using the [AttachedProperty](https://docs.microsoft.com/en-us/dotnet/framework/wpf/advanced/attached-properties-overview) of type List<GridSummaryColumn>.
+[WPF DataGrid](https://www.syncfusion.com/wpf-ui-controls/datagrid) (SfDataGrid) provides support to show the column summary. If the DataContext of `SfDataGrid` is ViewModel, you can bind [SummaryColumns](http://help.syncfusion.com/cr/cref_files/wpf/Syncfusion.SfGrid.WPF~Syncfusion.UI.Xaml.Grid.GridSummaryRow~SummaryColumns.html) to a property in ViewModel using the [AttachedProperty](https://docs.microsoft.com/en-us/dotnet/framework/wpf/advanced/attached-properties-overview) of type `List<GridSummaryColumn>`.
+
+Refer to the code example in the following KB article to define an `AttachedProperty` of type List<GridSummaryColumn>.
 
 KB article - [How to define summary rows using AttachedProperty in WPF and UWP DataGrid (SfDataGrid)](https://www.syncfusion.com/kb/9838/how-to-define-summary-rows-using-attached-property-in-wpf-datagrid-sfdatagrid)

--- a/README.md
+++ b/README.md
@@ -1,9 +1,107 @@
-# How to define summary rows using AttachedProperty in WPF and UWP DataGrid (SfDataGrid)?
+# How to Define Summary Rows using AttachedProperty in WPF / UWP DataGrid?
 
-This example illustrates how to define summary rows using [AttachedProperty](https://learn.microsoft.com/en-us/dotnet/desktop/wpf/properties/attached-properties-overview) in [WPF DataGrid](https://www.syncfusion.com/wpf-ui-controls/datagrid) (SfDataGrid).
+This example illustrates how to define summary rows using [AttachedProperty](https://learn.microsoft.com/en-us/dotnet/desktop/wpf/properties/attached-properties-overview) in [WPF DataGrid](https://www.syncfusion.com/wpf-ui-controls/datagrid) and [UWP DataGrid](https://www.syncfusion.com/uwp-ui-controls/datagrid) (SfDataGrid).
 
-[WPF DataGrid](https://www.syncfusion.com/wpf-ui-controls/datagrid) (SfDataGrid) provides support to show the column summary. If the DataContext of `SfDataGrid` is ViewModel, you can bind [SummaryColumns](http://help.syncfusion.com/cr/cref_files/wpf/Syncfusion.SfGrid.WPF~Syncfusion.UI.Xaml.Grid.GridSummaryRow~SummaryColumns.html) to a property in ViewModel using the [AttachedProperty](https://docs.microsoft.com/en-us/dotnet/framework/wpf/advanced/attached-properties-overview) of type `List<GridSummaryColumn>`.
+DataGrid provides support to show the column summary. If the DataContext of DataGrid is ViewModel, you can bind [SummaryColumns](https://help.syncfusion.com/cr/wpf/Syncfusion.UI.Xaml.Grid.GridSummaryRow.html#Syncfusion_UI_Xaml_Grid_GridSummaryRow_SummaryColumns) to a property in ViewModel using the AttachedProperty of type List &lt;GridSummaryColumn&gt;.
 
-Refer to the code example in the following KB article to define an `AttachedProperty` of type `List<GridSummaryColumn>`.
+Refer to the following code example to define the AttachedProperty of type List &lt;GridSummaryColumn&gt;.
 
-KB article - [How to define summary rows using AttachedProperty in WPF and UWP DataGrid (SfDataGrid)](https://www.syncfusion.com/kb/9838/how-to-define-summary-rows-using-attached-property-in-wpf-datagrid-sfdatagrid)
+#### C#
+
+``` csharp
+public class SfDataGridAttachedProperty
+{
+    public static readonly DependencyProperty DynamicSummaryColumnsProperty = DependencyProperty.RegisterAttached("DynamicSummaryColumns",
+        typeof(List<GridSummaryColumn>),
+        typeof(SfDataGridAttachedProperty)
+        , new FrameworkPropertyMetadata(null, OnDynamicSummaryColumnsChanged));
+
+    public static void SetDynamicSummaryColumns(UIElement element, List<GridSummaryColumn> value)
+    {
+        element.SetValue(DynamicSummaryColumnsProperty, value);
+    }
+    public static List<GridSummaryColumn> GetDynamicSummaryColumns(UIElement element)
+    {
+        return (List<GridSummaryColumn>)element.GetValue(DynamicSummaryColumnsProperty);
+    }
+
+    private static void OnDynamicSummaryColumnsChanged(DependencyObject d, DependencyPropertyChangedEventArgs args)
+    {
+        SfDataGrid grid = d as SfDataGrid;
+
+        if (grid.TableSummaryRows.Count() > 1)
+        {
+            grid.TableSummaryRows.Clear();
+        }
+
+        GridTableSummaryRow gsr = new GridTableSummaryRow();
+        gsr.ShowSummaryInRow = false;
+
+        var list = ((List<GridSummaryColumn>)args.NewValue);
+
+        foreach (var item in list)
+        {
+            gsr.SummaryColumns.Add(item);
+        }
+
+        grid.TableSummaryRows.Add(gsr);
+    }
+}
+```
+
+Refer to the following code example to populate GridSummaryColumn in Viewmodel.
+
+#### C#
+
+``` csharp
+internal class ViewModel : INotifyPropertyChanged
+{
+    private List<GridSummaryColumn> _summarycols;
+
+    public List<GridSummaryColumn> SummaryColumns
+    {
+        get { return _summarycols; }
+        set
+        {
+            _summarycols = value;
+            RaisePropertyChanged("SummaryColumns");
+        }
+    }
+
+    public ViewModel()
+    {
+        PopulateEmployeeDetails();
+        SetSummaryColumns();
+    }
+
+    private void SetSummaryColumns()
+    {
+        SummaryColumns = new List<GridSummaryColumn>();
+        SummaryColumns.Add(new GridSummaryColumn()
+        {
+            MappingName = "EmployeeID",
+            Name = "EmployeeID",
+            SummaryType = SummaryType.CountAggregate,
+            Format = "Total: {Count}"
+        });
+        SummaryColumns.Add(new GridSummaryColumn()
+        {
+            MappingName = "EmployeeSalary",
+            Name = "EmployeeSalary",
+            SummaryType = SummaryType.DoubleAggregate,
+            Format = "Total: {Sum}"
+        });
+    }
+}
+```
+
+Refer to the following code example to bind the attached property in DataGrid.
+
+#### XAML
+
+``` xml
+<Syncfusion:SfDataGrid x:Name="sfdatagrid"
+                       local:SfDataGridAttachedProperty.DynamicSummaryColumns="{Binding SummaryColumns}"
+                       ItemsSource="{Binding EmployeeDetails}">
+</Syncfusion:SfDataGrid>
+```


### PR DESCRIPTION
## Description: ##

Resolved the ReadMe length issue in this sample repository. 

**Task:** [Task 975464 Resolve Issues in Public Syncfusion Code Examples for DataGrid XAML Controls](https://dev.azure.com/EssentialStudio/Mobile%20and%20Desktop/_workitems/edit/975464)

**KB Article:** https://support.syncfusion.com/kb/article/8658/how-to-define-summary-rows-using-attached-property-in-wpf-datagrid-

## Preview Image: ##

<img width="861" height="306" alt="image" src="https://github.com/user-attachments/assets/acd08511-76cd-45b2-aa41-3712b2408f48" />
